### PR TITLE
Non chunk mode

### DIFF
--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/AbstractProducer.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/AbstractProducer.java
@@ -78,7 +78,7 @@ public abstract class AbstractProducer implements Producer {
     }
 
     public BigInteger createSecretBase(CProducer cProducer, BigInteger secret, boolean logSecretBase) {
-        BigInteger secretBase = cProducer.killBits(secret);
+        BigInteger secretBase = cProducer.setLeastSignificantBitToZero(secret);
         
         if(logSecretBase) {
             logger.info("secretBase: " + org.bouncycastle.util.encoders.Hex.toHexString(secretBase.toByteArray()) + "/" + cProducer.gridNumBits);
@@ -96,10 +96,6 @@ public abstract class AbstractProducer implements Producer {
     }
     
     public static BigInteger calculateSecretKey(BigInteger secretBase, int keyNumber) {
-        if (false) {
-            // works also but a or might be faster
-            return secretBase.add(BigInteger.valueOf(keyNumber));
-        }
         return secretBase.or(BigInteger.valueOf(keyNumber));
     }
     

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/InvalidWorkSizeException.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/InvalidWorkSizeException.java
@@ -1,0 +1,10 @@
+package net.ladenthin.bitcoinaddressfinder;
+
+public class InvalidWorkSizeException extends Exception {
+
+	private static final long serialVersionUID = 1716547986284729020L;
+
+	public InvalidWorkSizeException(String msg) {
+		super(msg);
+	}
+}

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/KeyUtility.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/KeyUtility.java
@@ -63,7 +63,7 @@ public class KeyUtility {
         return address.toBase58();
     }
 
-    public BigInteger createSecret(int maximumBitLength, Random random) {
+    public static BigInteger createSecret(int maximumBitLength, Random random) {
         BigInteger secret = new BigInteger(maximumBitLength, random);
         return secret;
     }

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/KeyUtility.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/KeyUtility.java
@@ -231,4 +231,14 @@ public class KeyUtility {
         }
         return bytes;
     }
+
+    public static byte[] bigIntegersToBytes(BigInteger[] privateKeys) {
+        byte[] bytes = new byte[PublicKeyBytes.PRIVATE_KEY_MAX_NUM_BYTES * privateKeys.length];
+        for (int i = 0; i < privateKeys.length; i++) {
+            byte[] loopBytes = bigIntegerToBytes(privateKeys[i]);
+            int offset = i * PublicKeyBytes.PRIVATE_KEY_MAX_NUM_BYTES;
+            System.arraycopy(loopBytes, 0, bytes, offset, loopBytes.length);
+        }
+        return bytes;
+    }
 }

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/KeyUtility.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/KeyUtility.java
@@ -240,39 +240,4 @@ public class KeyUtility {
         }
         return bytes;
     }
-
-    /**
-     * Makes sure, that the given BigInteger will have at least 32 bytes. This method will add leading zeros to ensure this.
-     *
-     * @param number the BigInteger to check
-     * @return the BigInteger with at least 32 bytes.
-     */
-    public static BigInteger ensureMinByteLength(BigInteger number) {
-        String rawNumberAsHex = number.toString(16);
-        if (rawNumberAsHex.length() < 64) {
-            int leadingZeroCount = 64 - (rawNumberAsHex.length());
-            StringBuilder sb = new StringBuilder();
-
-            // Add leading zeros
-            for (int ii = 0; ii < leadingZeroCount; ii++) {
-                sb.append("0");
-            }
-            sb.append(rawNumberAsHex);
-            String val = sb.toString();
-            number = new BigInteger(val, 16);
-        }
-        return number;
-    }
-
-    /**
-     * Makes sure, that all {@link BigInteger} in the given array will have at least 32 bytes.
-     * This method will add leading zeros to ensure this.
-     *
-     * @param numberArray the array containing {@link BigInteger} to check
-     */
-    public static void ensureMinByteLength(BigInteger[] numberArray) {
-        for (int i = 0; i < numberArray.length; i++) {
-            numberArray[i] = ensureMinByteLength(numberArray[i]);
-        }
-    }
 }

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/KeyUtility.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/KeyUtility.java
@@ -220,7 +220,6 @@ public class KeyUtility {
      * BigInteger, according to SRP specification
      *
      * @param bigInteger BigInteger, must not be null
-     *
      * @return byte array (leading byte is always != 0), empty array if
      * BigInteger is zero.
      */
@@ -242,25 +241,38 @@ public class KeyUtility {
         return bytes;
     }
 
+    /**
+     * Makes sure, that the given BigInteger will have at least 32 bytes. This method will add leading zeros to ensure this.
+     *
+     * @param number the BigInteger to check
+     * @return the BigInteger with at least 32 bytes.
+     */
+    public static BigInteger ensureMinByteLength(BigInteger number) {
+        String rawNumberAsHex = number.toString(16);
+        if (rawNumberAsHex.length() < 64) {
+            int leadingZeroCount = 64 - (rawNumberAsHex.length());
+            StringBuilder sb = new StringBuilder();
+
+            // Add leading zeros
+            for (int ii = 0; ii < leadingZeroCount; ii++) {
+                sb.append("0");
+            }
+            sb.append(rawNumberAsHex);
+            String val = sb.toString();
+            number = new BigInteger(val, 16);
+        }
+        return number;
+    }
+
+    /**
+     * Makes sure, that all {@link BigInteger} in the given array will have at least 32 bytes.
+     * This method will add leading zeros to ensure this.
+     *
+     * @param numberArray the array containing {@link BigInteger} to check
+     */
     public static void ensureMinByteLength(BigInteger[] numberArray) {
         for (int i = 0; i < numberArray.length; i++) {
-            String rawNumberAsHex = numberArray[i].toString(16);
-            if (rawNumberAsHex.length() < 64) {
-                int leadingZeroCount = 64 - (rawNumberAsHex.length());
-                StringBuilder sb = new StringBuilder();
-
-                // Add leading zeros
-                for (int ii = 0; ii < leadingZeroCount; ii++) {
-                    sb.append("0");
-                }
-                sb.append(rawNumberAsHex);
-                String val = sb.toString();
-                if(val.length() != 64){
-                    System.out.println("stress");
-                }
-                BigInteger bigInteger = new BigInteger(val, 16);
-                numberArray[i] = bigInteger;
-            }
+            numberArray[i] = ensureMinByteLength(numberArray[i]);
         }
     }
 }

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/KeyUtility.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/KeyUtility.java
@@ -241,4 +241,26 @@ public class KeyUtility {
         }
         return bytes;
     }
+
+    public static void ensureMinByteLength(BigInteger[] numberArray) {
+        for (int i = 0; i < numberArray.length; i++) {
+            String rawNumberAsHex = numberArray[i].toString(16);
+            if (rawNumberAsHex.length() < 64) {
+                int leadingZeroCount = 64 - (rawNumberAsHex.length());
+                StringBuilder sb = new StringBuilder();
+
+                // Add leading zeros
+                for (int ii = 0; ii < leadingZeroCount; ii++) {
+                    sb.append("0");
+                }
+                sb.append(rawNumberAsHex);
+                String val = sb.toString();
+                if(val.length() != 64){
+                    System.out.println("stress");
+                }
+                BigInteger bigInteger = new BigInteger(val, 16);
+                numberArray[i] = bigInteger;
+            }
+        }
+    }
 }

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/OpenCLContext.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/OpenCLContext.java
@@ -102,6 +102,11 @@ public class OpenCLContext {
         this.producerOpenCL = producerOpenCL;
     }
     
+    /**
+     * Sets all properties and parameters to finally create the OpenCL kernel.
+     *
+     * @throws IOException When an error occurs while reading a resource.
+     */
     public void init() throws IOException {
         
         // #################### general ####################
@@ -160,7 +165,7 @@ public class OpenCLContext {
         openClTask = new OpenClTask(context, producerOpenCL);
     }
 
-    OpenClTask getOpenClTask() {
+    protected OpenClTask getOpenClTask() {
         return openClTask;
     }
 
@@ -172,6 +177,15 @@ public class OpenCLContext {
         clReleaseContext(context);
     }
 
+    /**
+     * This method executes the OpenCL kernel to generate publicKeys. Depending on the parameter <strong>chunkMode</strong> it
+     * will automatically generate new privateKeys based on the first privateKey that was passed.
+     *
+     * @param privateKeys In case of <strong>chunkMode = true</strong> this method only needs
+     *                    one privateKey, but in case of <strong>chunkMode = false</strong>
+     *                    it needs exactly as many private keys as the work size.
+     * @return publicKeys as {@link OpenCLGridResult}
+     */
     public OpenCLGridResult createKeys(BigInteger[] privateKeys) {
         openClTask.setSrcPrivateKeys(privateKeys);
         ByteBuffer dstByteBuffer = openClTask.executeKernel(kernel, commandQueue);

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/OpenCLContext.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/OpenCLContext.java
@@ -187,7 +187,6 @@ public class OpenCLContext {
      * @return publicKeys as {@link OpenCLGridResult}
      */
     public OpenCLGridResult createKeys(BigInteger[] privateKeys) {
-        KeyUtility.ensureMinByteLength(privateKeys);
         openClTask.setSrcPrivateKeys(privateKeys);
         ByteBuffer dstByteBuffer = openClTask.executeKernel(kernel, commandQueue);
 

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/OpenCLContext.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/OpenCLContext.java
@@ -83,8 +83,8 @@ public class OpenCLContext {
         resourceNames.add("inc_ecc_secp256k1custom.cl");
         return resourceNames;
     }
-    
-    private final static String KERNEL_NAME = "generateKeysKernel_grid";
+
+    private final static String CHUNK_KERNEL_NAME = "generateKeyChunkKernel_grid";
     private final static boolean EXCEPTIONS_ENABLED = true;
     
     private final CProducerOpenCL producerOpenCL;
@@ -150,7 +150,7 @@ public class OpenCLContext {
         clBuildProgram(program, 0, null, null, null, null);
         
         // Create the kernel
-        kernel = clCreateKernel(program, KERNEL_NAME, null);
+        kernel = clCreateKernel(program, CHUNK_KERNEL_NAME, null);
         
         openClTask = new OpenClTask(context, producerOpenCL);
     }

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/OpenCLContext.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/OpenCLContext.java
@@ -84,6 +84,7 @@ public class OpenCLContext {
         return resourceNames;
     }
 
+    private final static String NON_CHUNK_KERNEL_NAME = "generateKeysKernel_grid";
     private final static String CHUNK_KERNEL_NAME = "generateKeyChunkKernel_grid";
     private final static boolean EXCEPTIONS_ENABLED = true;
     

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/OpenCLContext.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/OpenCLContext.java
@@ -187,6 +187,7 @@ public class OpenCLContext {
      * @return publicKeys as {@link OpenCLGridResult}
      */
     public OpenCLGridResult createKeys(BigInteger[] privateKeys) {
+        KeyUtility.ensureMinByteLength(privateKeys);
         openClTask.setSrcPrivateKeys(privateKeys);
         ByteBuffer dstByteBuffer = openClTask.executeKernel(kernel, commandQueue);
 

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/OpenCLGridResult.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/OpenCLGridResult.java
@@ -1,19 +1,18 @@
 // @formatter:off
-/**
+/*
  * Copyright 2020 Bernard Ladenthin bernard.ladenthin@gmail.com
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 // @formatter:on
 package net.ladenthin.bitcoinaddressfinder;
@@ -24,6 +23,7 @@ import java.nio.ByteBuffer;
 public class OpenCLGridResult {
 
     private final ByteBufferUtility byteBufferUtility = new ByteBufferUtility(true);
+
     private final BigInteger[] secretKeys;
     private final int workSize;
     private final boolean chunkMode;
@@ -49,22 +49,20 @@ public class OpenCLGridResult {
         }
     }
 
-    public int getWorkSize() {
-        return workSize;
-    }
-
     public ByteBuffer getResult() {
         return result;
     }
-    
+
+    /**
+     * Frees byte buffer and sets result to NULL
+     */
     public void freeResult() {
-        // free and do not use anymore
         byteBufferUtility.freeByteBuffer(result);
         result = null;
     }
-    
+
     /**
-     * Time consuming.
+     * @return the calculated public keys
      */
     public PublicKeyBytes[] getPublicKeyBytes() {
         PublicKeyBytes[] publicKeys = new PublicKeyBytes[workSize];
@@ -81,50 +79,40 @@ public class OpenCLGridResult {
         }
         return publicKeys;
     }
-    
+
     /**
      * Read the inner bytes in reverse order.
      */
-    private static final PublicKeyBytes getPublicKeyFromByteBufferXY(ByteBuffer b, int keyNumber, BigInteger secretKeyBase) {
+    private static PublicKeyBytes getPublicKeyFromByteBufferXY(ByteBuffer b, int keyNumber,
+                                                               BigInteger secretKeyBase) {
+
         BigInteger secret = AbstractProducer.calculateSecretKey(secretKeyBase, keyNumber);
-        if(BigInteger.ZERO.equals(secret)) {
-            // the calculated key is invalid, return a fallback
+
+        if (BigInteger.ZERO.equals(secret)) {
             return PublicKeyBytes.INVALID_KEY_ONE;
         }
+
         byte[] uncompressed = new byte[PublicKeyBytes.PUBLIC_KEY_UNCOMPRESSED_BYTES];
         uncompressed[0] = PublicKeyBytes.PARITY_UNCOMPRESSED;
-        
-        int keyOffsetInByteBuffer = PublicKeyBytes.TWO_COORDINATES_NUM_BYTES*keyNumber;
-        
+
+        // Same way as in OpenCL kernel:
+        // int r_offset = PUBLIC_KEY_LENGTH_X_Y_WITHOUT_PARITY * global_id;
+        int keyOffsetInByteBuffer = PublicKeyBytes.TWO_COORDINATES_NUM_BYTES * keyNumber;
+
         // read ByteBuffer
         byte[] yx = new byte[PublicKeyBytes.TWO_COORDINATES_NUM_BYTES];
         for (int i = 0; i < PublicKeyBytes.TWO_COORDINATES_NUM_BYTES; i++) {
-            yx[yx.length-1-i] = b.get(keyOffsetInByteBuffer+i);
+            yx[yx.length - 1 - i] = b.get(keyOffsetInByteBuffer + i);
         }
-        
+
         // copy x
-        System.arraycopy(yx, PublicKeyBytes.ONE_COORDINATE_NUM_BYTES, uncompressed, PublicKeyBytes.PARITY_BYTES_LENGTH, PublicKeyBytes.ONE_COORDINATE_NUM_BYTES);
+        System.arraycopy(yx, PublicKeyBytes.ONE_COORDINATE_NUM_BYTES, uncompressed, PublicKeyBytes.PARITY_BYTES_LENGTH,
+                PublicKeyBytes.ONE_COORDINATE_NUM_BYTES);
         // copy y
-        System.arraycopy(yx, 0, uncompressed, PublicKeyBytes.PARITY_BYTES_LENGTH+PublicKeyBytes.ONE_COORDINATE_NUM_BYTES, PublicKeyBytes.ONE_COORDINATE_NUM_BYTES);
-        
-        if (false) {
-            assertValidResult(uncompressed);
-        }
-        PublicKeyBytes publicKeyBytes = new PublicKeyBytes(secret, uncompressed);
-        return publicKeyBytes;
+        System.arraycopy(yx, 0, uncompressed,
+                PublicKeyBytes.PARITY_BYTES_LENGTH + PublicKeyBytes.ONE_COORDINATE_NUM_BYTES,
+                PublicKeyBytes.ONE_COORDINATE_NUM_BYTES);
+
+        return new PublicKeyBytes(secret, uncompressed);
     }
-    
-    private static void assertValidResult(byte[] uncompressed) {
-        boolean invalid = true;
-        for (int i = 1; i < uncompressed.length; i++) {
-            if (uncompressed[i] != 0) {
-                invalid = false;
-                break;
-            }
-        }
-        if (invalid) {
-            throw new RuntimeException("Invalid result from GPU, all uncompressed key bytes are 0.");
-        }
-    }
-    
 }

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/OpenClTask.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/OpenClTask.java
@@ -78,15 +78,19 @@ public class OpenClTask {
     }
 
     public int getSrcSizeInBytes() {
-        return PublicKeyBytes.PRIVATE_KEY_MAX_NUM_BYTES;
+        if (cProducer.chunkMode) {
+            return PublicKeyBytes.PRIVATE_KEY_MAX_NUM_BYTES;
+        } else {
+            return PublicKeyBytes.PRIVATE_KEY_MAX_NUM_BYTES * cProducer.getWorkSize();
+        }
     }
 
     public int getDstSizeInBytes() {
         return PublicKeyBytes.TWO_COORDINATES_NUM_BYTES * cProducer.getWorkSize();
     }
 
-    public void setSrcPrivateKeyChunk(BigInteger privateKeyBase) {
-        byte[] privateKeyChunkAsByteArray = KeyUtility.bigIntegerToBytes(privateKeyBase);
+    public void setSrcPrivateKeys(BigInteger[] privateKeys) {
+        byte[] privateKeyChunkAsByteArray = KeyUtility.bigIntegersToBytes(privateKeys);
 
         // put key in reverse order because the ByteBuffer put writes in reverse order, a flip has no effect
         reverse(privateKeyChunkAsByteArray);

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/ProducerOpenCL.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/ProducerOpenCL.java
@@ -60,9 +60,10 @@ public class ProducerOpenCL extends AbstractProducer {
             }
 
             final BigInteger secretBase = createSecretBase(producerOpenCL, secret, producerOpenCL.logSecretBase);
+            BigInteger[] privateKeys = {secretBase};
 
             waitTillFreeThreadsInPool();
-            OpenCLGridResult createKeys = openCLContext.createKeys(secretBase);
+            OpenCLGridResult createKeys = openCLContext.createKeys(privateKeys);
             
             resultReaderThreadPoolExecutor.submit(
                 () ->{

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/PublicKeyBytes.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/PublicKeyBytes.java
@@ -114,13 +114,15 @@ public class PublicKeyBytes {
     public boolean isInvalid() {
         return isInvalid(secretKey);
     }
-    
+
+    /**
+     * Prevent an IllegalArgumentException
+     *
+     * @param secret to be checked if invalid
+     * @return <strong>true</strong> when secret equals 0000 or 0001
+     */
     public static boolean isInvalid(BigInteger secret) {
-        if (BigInteger.ZERO.equals(secret) || BigInteger.ONE.equals(secret)) {
-            // prevent an IllegalArgumentException
-            return true;
-        }
-        return false;
+        return BigInteger.ZERO.equals(secret) || BigInteger.ONE.equals(secret);
     }
     
     public PublicKeyBytes(BigInteger secretKey, byte[] uncompressed) {

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/configuration/CProducer.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/configuration/CProducer.java
@@ -55,6 +55,9 @@ public class CProducer {
      */
     public boolean logSecretBase;
 
+    /**
+     * @return {@code 1 << gridNumBits} in decimal
+     */
     public int getWorkSize() {
         return 1 << gridNumBits;
     }
@@ -65,9 +68,18 @@ public class CProducer {
         }
         return killBits;
     }
-    
-    public BigInteger killBits(BigInteger bigInteger) {
-        return bigInteger.andNot(getKillBits());
+
+    /**
+     * Sets the <strong>LEAST SIGNIFICANT BIT</strong> of the given value to 0 depending on the numbers of bits in the grid {@inheritDoc gridNumBits}
+     * <p>
+     * Example: 1011 becomes 1010 if numbers of bits in grid is 4
+     *
+     * @param value to be manipulated
+     * @return value with the LSB set to 0, rest remains untouched
+     */
+    public BigInteger setLeastSignificantBitToZero(BigInteger value) {
+        BigInteger killBits = getKillBits();
+        return value.andNot(killBits);
     }
     
     public void assertGridNumBitsCorrect() {

--- a/src/main/java/net/ladenthin/bitcoinaddressfinder/configuration/CProducer.java
+++ b/src/main/java/net/ladenthin/bitcoinaddressfinder/configuration/CProducer.java
@@ -31,6 +31,14 @@ public class CProducer {
     public static final int MAX_GRID_NUM_BITS = 24;
     
     /**
+     * <code>chunkMode = TRUE</code> means, that we only provide a single privateKey and the OpenCL kernel will
+     * calculate new privateKeys ("chunks") out of the first one by doint bitwise or-operations with
+     * the global_ID of the kernel.
+     * <code>chunkMode = FALSE</code> means, that we will only use provided privateKeys and do not calculate new ones
+     */
+    public boolean chunkMode;
+
+    /**
      * (2<sup>{@code maxNumBits}</sup> - 1) can be set to a lower value to improve a search on specific ranges (e.g. the puzzle transaction https://privatekeys.pw/puzzles/bitcoin-puzzle-tx ).
      * {@code 1} can't be tested because {@link ECKey#fromPrivate} throws an {@link IllegalArgumentException}.
      * Range: {@code 2} (inclusive) to {@link PublicKeyBytes#PRIVATE_KEY_MAX_NUM_BITS} (inclusive).

--- a/src/main/resources/inc_ecc_secp256k1custom.cl
+++ b/src/main/resources/inc_ecc_secp256k1custom.cl
@@ -204,6 +204,72 @@ __kernel void generateKeyChunkKernel_grid(__global u32 *r, __global const u32 *k
     r[r_offset+15] = y_local[7];
 }
 
+/*
+ * Generates the public key
+ * @param r out: result storing private key and the calculated address
+ * @param k in: private key grid
+ */
+__kernel void generateKeysKernel_grid(__global u32 *r, __global const u32 *k) {
+  u32 x_local[PUBLIC_KEY_LENGTH_WITHOUT_PARITY];
+  u32 y_local[PUBLIC_KEY_LENGTH_WITHOUT_PARITY];
+  u32 k_local[PRIVATE_KEY_LENGTH];
+  secp256k1_t g_xy_local;
+
+  // get_global_id(dim) where dim is the dimension index (0 for first, 1 for
+  // second dimension etc.) The above call is equivalent to
+  // get_local_size(dim)*get_group_id(dim) + get_local_id(dim) size_t global_id
+  // = get_global_id(0);
+  u32 global_id = get_global_id(0);
+
+  // int local_id = get_local_id(0);
+  // int local_size = get_local_size(0);
+
+  // new offset for private keys
+  int k_offset = PRIVATE_KEY_LENGTH * global_id;
+
+  // get private key from private key grid
+  k_local[0] = k[0 + k_offset];
+  k_local[1] = k[1 + k_offset];
+  k_local[2] = k[2 + k_offset];
+  k_local[3] = k[3 + k_offset];
+  k_local[4] = k[4 + k_offset];
+  k_local[5] = k[5 + k_offset];
+  k_local[6] = k[6 + k_offset];
+  k_local[7] = k[7 + k_offset];
+
+  set_precomputed_basepoint_g(&g_xy_local);
+
+  // calculating the public key
+  // K = public key
+  // k = private key
+  // G = generator point (pre-calculated)
+  // K = k * G
+  point_mul_xy(x_local, y_local, k_local, &g_xy_local);
+
+  int r_offset = PUBLIC_KEY_LENGTH_X_Y_WITHOUT_PARITY * global_id;
+
+  // local to global
+  // x
+  r[r_offset + 0] = x_local[0];
+  r[r_offset + 1] = x_local[1];
+  r[r_offset + 2] = x_local[2];
+  r[r_offset + 3] = x_local[3];
+  r[r_offset + 4] = x_local[4];
+  r[r_offset + 5] = x_local[5];
+  r[r_offset + 6] = x_local[6];
+  r[r_offset + 7] = x_local[7];
+
+  // y
+  r[r_offset + 8] = y_local[0];
+  r[r_offset + 9] = y_local[1];
+  r[r_offset + 10] = y_local[2];
+  r[r_offset + 11] = y_local[3];
+  r[r_offset + 12] = y_local[4];
+  r[r_offset + 13] = y_local[5];
+  r[r_offset + 14] = y_local[6];
+  r[r_offset + 15] = y_local[7];
+}
+
 __kernel void test_kernel_do_nothing(__global u32 *r, __global const u32 *k)
 {
 }

--- a/src/main/resources/inc_ecc_secp256k1custom.cl
+++ b/src/main/resources/inc_ecc_secp256k1custom.cl
@@ -151,7 +151,7 @@ __kernel void generateKeysKernel_transform_public(__global u32 *r, __global cons
     r[8] = r_local[8];
 }
 
-__kernel void generateKeysKernel_grid(__global u32 *r, __global const u32 *k)
+__kernel void generateKeyChunkKernel_grid(__global u32 *r, __global const u32 *k)
 {
     u32 x_local[PUBLIC_KEY_LENGTH_WITHOUT_PARITY];
     u32 y_local[PUBLIC_KEY_LENGTH_WITHOUT_PARITY];

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/KeyUtilityTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/KeyUtilityTest.java
@@ -191,11 +191,11 @@ public class KeyUtilityTest {
         byte[] keyWithoutLeadingZeros = KeyUtility.bigIntegerToBytes(key);
 
         // assert
-        assertThat(keyWithoutLeadingZeros.length, is(equalTo(32)));
+        assertThat(keyWithoutLeadingZeros.length, is(equalTo(PublicKeyBytes.PRIVATE_KEY_MAX_NUM_BYTES)));
         
         // copy back
         byte[] arrayWithLeadingZero = new byte[33];
-        System.arraycopy(keyWithoutLeadingZeros, 0, arrayWithLeadingZero, 1, 32);
+        System.arraycopy(keyWithoutLeadingZeros, 0, arrayWithLeadingZero, 1, PublicKeyBytes.PRIVATE_KEY_MAX_NUM_BYTES);
         
         // assert content equals
         assertThat(arrayWithLeadingZero, is(equalTo(maxPrivateKey)));

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/OpenCLContextTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/OpenCLContextTest.java
@@ -19,7 +19,6 @@ public class OpenCLContextTest {
     public static final int CHUNK_SIZE = 256;
 
     private static final String PRIVATE_KEY_HEX_STRING = "c297e4944f46f3b9f04cf4b3984f49bd4ee40dec33991066fa15cdb227933469";
-    private static final String SHORT_PRIVATE_KEY_HEX_STRING = "b5e704f9052318d6476e50521850634fac256bb46aa6b791f17163dc980e70";
 
     private static final String PUBLIC_KEY_HEX_STRING = "045f399867ee13c5ac525259f036c90f455b11d667acfcdfc36791288547633611e8416a53aea83bd55691a5721775a581bd1e8e09dd3db4021a6f6daebdbcc9da";
     private static final boolean CHUNK_MODE = true;

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/OpenCLContextTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/OpenCLContextTest.java
@@ -85,7 +85,24 @@ public class OpenCLContextTest {
 
     @Test
     public void test_generate256PublicKeys_randomPrivateKeys_nonChunkMode() {
-        // TODO write test
+        //arrange
+        BigInteger[] privateKeysArray = TestHelper.generateRandomUncompressedPrivateKeys(CHUNK_SIZE);
+        OpenCLContext openCLContext = TestHelper.createOpenCLContext(false);
+
+        // act
+        OpenCLGridResult openCLGridResult = openCLContext.createKeys(privateKeysArray);
+        PublicKeyBytes[] publicKeysResult = openCLGridResult.getPublicKeyBytes();
+
+        // cleanup
+        openCLContext.release();
+        openCLGridResult.freeResult();
+
+        // assert
+        KeyUtility.ensureMinByteLength(privateKeysArray);
+        Map<String, String> resultKeysMap = TestHelper.createMapFromBigIntegerArrayAndPublicKeyBytesArray(privateKeysArray, publicKeysResult);
+        String[] expectedPublicKeysAsHexStringArray = TestHelper.uncompressedPublicKeysHexStringArrayFromPrivateKeysArray(privateKeysArray);
+        Map<String, String> expectedKeysMap = TestHelper.createMapFromSecretAndPublicKeys(privateKeysArray, expectedPublicKeysAsHexStringArray);
+        assertThatKeyMap(resultKeysMap).isEqualTo(expectedKeysMap);
     }
 
     @Ignore

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/OpenCLContextTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/OpenCLContextTest.java
@@ -19,6 +19,8 @@ public class OpenCLContextTest {
     public static final int CHUNK_SIZE = 256;
 
     private static final String PRIVATE_KEY_HEX_STRING = "c297e4944f46f3b9f04cf4b3984f49bd4ee40dec33991066fa15cdb227933469";
+    private static final String SHORT_PRIVATE_KEY_HEX_STRING = "b5e704f9052318d6476e50521850634fac256bb46aa6b791f17163dc980e70";
+
     private static final String PUBLIC_KEY_HEX_STRING = "045f399867ee13c5ac525259f036c90f455b11d667acfcdfc36791288547633611e8416a53aea83bd55691a5721775a581bd1e8e09dd3db4021a6f6daebdbcc9da";
     private static final boolean CHUNK_MODE = true;
 
@@ -98,7 +100,6 @@ public class OpenCLContextTest {
         openCLGridResult.freeResult();
 
         // assert
-        KeyUtility.ensureMinByteLength(privateKeysArray);
         Map<String, String> resultKeysMap = TestHelper.createMapFromBigIntegerArrayAndPublicKeyBytesArray(privateKeysArray, publicKeysResult);
         String[] expectedPublicKeysAsHexStringArray = TestHelper.uncompressedPublicKeysHexStringArrayFromPrivateKeysArray(privateKeysArray);
         Map<String, String> expectedKeysMap = TestHelper.createMapFromSecretAndPublicKeys(privateKeysArray, expectedPublicKeysAsHexStringArray);

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/OpenCLContextTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/OpenCLContextTest.java
@@ -1,0 +1,126 @@
+package net.ladenthin.bitcoinaddressfinder;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.math.BigInteger;
+import java.util.Map;
+
+import static net.ladenthin.bitcoinaddressfinder.TestHelper.assertThatKeyMap;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Tests the publicKey and address calculation of an OpenClContext without considering the performance.
+ */
+public class OpenCLContextTest {
+
+    public static final int CHUNK_SIZE = 256;
+
+    private static final String PRIVATE_KEY_HEX_STRING = "c297e4944f46f3b9f04cf4b3984f49bd4ee40dec33991066fa15cdb227933469";
+    private static final String PUBLIC_KEY_HEX_STRING = "045f399867ee13c5ac525259f036c90f455b11d667acfcdfc36791288547633611e8416a53aea83bd55691a5721775a581bd1e8e09dd3db4021a6f6daebdbcc9da";
+    private static final boolean CHUNK_MODE = true;
+
+    @Test
+    public void test_generateSinglePublicKey_specificPrivateKey() {
+        // arrange
+        BigInteger[] privateKeysArray = TestHelper.createBigIntegerArrayFromSingleHexString(PRIVATE_KEY_HEX_STRING);
+        OpenCLContext openCLContext = TestHelper.createOpenCLContext(CHUNK_MODE);
+
+        // act
+        OpenCLGridResult openCLGridResult = openCLContext.createKeys(privateKeysArray);
+        PublicKeyBytes[] publicKeysResult = openCLGridResult.getPublicKeyBytes();
+
+        // cleanup
+        openCLContext.release();
+        openCLGridResult.freeResult();
+
+        // assert
+        String resultPublicKeyAsHexString = TestHelper.hexStringFromPublicKeyBytes(publicKeysResult[0]);
+        assertThat(resultPublicKeyAsHexString, is(equalTo(PUBLIC_KEY_HEX_STRING)));
+    }
+
+    @Test
+    public void test_generateSinglePublicKey_randomPrivateKey() {
+        //arrange
+        BigInteger[] privateKeysArray = TestHelper.generateRandomUncompressedPrivateKeys(1);
+        OpenCLContext openCLContext = TestHelper.createOpenCLContext(CHUNK_MODE);
+
+        // act
+        OpenCLGridResult openCLGridResult = openCLContext.createKeys(privateKeysArray);
+        PublicKeyBytes[] publicKeysResult = openCLGridResult.getPublicKeyBytes();
+
+        // cleanup
+        openCLContext.release();
+        openCLGridResult.freeResult();
+
+        // assert
+        String resultPublicKeyAsHexString = TestHelper.hexStringFromPublicKeyBytes(publicKeysResult[0]);
+        String expectedPublicKeyAsHexString = TestHelper.uncompressedPublicKeyHexStringFromPrivateKey(privateKeysArray[0]);
+        assertThat(resultPublicKeyAsHexString, is(equalTo(expectedPublicKeyAsHexString)));
+    }
+
+    @Test
+    public void test_generate256PublicKeys_specificPrivateKey_chunkMode() {
+        //arrange
+        BigInteger[] privateKeysArray = TestHelper.createBigIntegerArrayFromSingleHexString(PRIVATE_KEY_HEX_STRING);
+        OpenCLContext openCLContext = TestHelper.createOpenCLContext(CHUNK_MODE);
+
+        // act
+        OpenCLGridResult openCLGridResult = openCLContext.createKeys(privateKeysArray);
+        PublicKeyBytes[] publicKeysResult = openCLGridResult.getPublicKeyBytes();
+
+        // cleanup
+        openCLContext.release();
+        openCLGridResult.freeResult();
+
+        // assert
+        BigInteger[] privateKeysChunk = TestHelper.generateChunkOutOfSinglePrivateKey(privateKeysArray[0], CHUNK_SIZE);
+        Map<String, String> resultKeysMap = TestHelper.createMapFromBigIntegerArrayAndPublicKeyBytesArray(privateKeysChunk, publicKeysResult);
+        String[] expectedPublicKeysAsHexStringArray = TestHelper.uncompressedPublicKeysHexStringArrayFromPrivateKeysArray(privateKeysChunk);
+        Map<String, String> expectedKeysMap = TestHelper.createMapFromSecretAndPublicKeys(privateKeysChunk, expectedPublicKeysAsHexStringArray);
+        assertThatKeyMap(resultKeysMap).isEqualTo(expectedKeysMap);
+    }
+
+    @Test
+    public void test_generate256PublicKeys_randomPrivateKeys_nonChunkMode() {
+        // TODO write test
+    }
+
+    @Ignore
+    @Test
+    public void test_generateSingleAddress_specificPublicKey() {
+        // TODO write test
+    }
+
+    @Ignore
+    @Test
+    public void test_generateSingleAddress_randomPublicKey() {
+        // TODO write test
+    }
+
+    @Ignore
+    @Test
+    public void test_generateSingleAddress_specificPrivateKey() {
+        // TODO write test
+    }
+
+    @Ignore
+    @Test
+    public void test_generateSingleAddress_randomPrivateKey() {
+        // TODO write test
+    }
+
+    @Ignore
+    @Test
+    public void test_generate256Addresses_randomPublicKeys() {
+        // TODO write test
+    }
+
+    @Ignore
+    @Test
+    public void test_generate256Addresses_randomPrivateKeys() {
+        // TODO write test
+    }
+}

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/ProbeAddressesOpenCLTest.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/ProbeAddressesOpenCLTest.java
@@ -416,7 +416,7 @@ public class ProbeAddressesOpenCLTest {
         
         Random sr = new SecureRandom();
         BigInteger secret = keyUtility.createSecret(bitSize, sr);
-        BigInteger secretBase = producerOpenCL.killBits(secret);
+        BigInteger secretBase = producerOpenCL.setLeastSignificantBitToZero(secret);
         BigInteger[] secrets = { secretBase };
 
         openCLContext.createKeys(secrets);
@@ -439,7 +439,7 @@ public class ProbeAddressesOpenCLTest {
         
         Random sr = new SecureRandom();
         BigInteger secret = keyUtility.createSecret(BITS_FOR_GRID-1, sr);
-        BigInteger secretBase = producerOpenCL.killBits(secret);
+        BigInteger secretBase = producerOpenCL.setLeastSignificantBitToZero(secret);
         
         BigInteger[] secrets = { secretBase };
 
@@ -493,7 +493,7 @@ public class ProbeAddressesOpenCLTest {
         Random sr = new SecureRandom();
 
         BigInteger secret = keyUtility.createSecret(PublicKeyBytes.PRIVATE_KEY_MAX_NUM_BITS, sr);
-        BigInteger secretBase = producerOpenCL.killBits(secret);
+        BigInteger secretBase = producerOpenCL.setLeastSignificantBitToZero(secret);
         
         BigInteger[] privateKeys = { secretBase };
         OpenCLGridResult createKeys = openCLContext.createKeys(privateKeys);

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/TestHelper.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/TestHelper.java
@@ -13,7 +13,8 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 public class TestHelper {
 
@@ -45,7 +46,7 @@ public class TestHelper {
         BigInteger[] privateKeys = new BigInteger[arraySize];
         for (int i = 0; i < arraySize; i++) {
             privateKeys[i] = KeyUtility.createSecret(PRIVATE_KEY_MAX_BIT_LENGTH, new SecureRandom());
-            privateKeys[i] = ensureMinBitLength(privateKeys[i]);
+            KeyUtility.ensureMinByteLength(privateKeys[i]);
             if (!validateBitcoinPrivateKey(privateKeys[i].toString(HEX_RADIX))) {
                 System.out.println(i + ": NOT VALID: " + privateKeys[i].toString(HEX_RADIX));
             }
@@ -68,16 +69,6 @@ public class TestHelper {
         return privateKey.compareTo(minPrivateKey) >= 0 && privateKey.compareTo(maxPrivateKey) <= 0;
     }
 
-    private static BigInteger ensureMinBitLength(BigInteger privateKey) {
-        if (privateKey.bitLength() < PRIVATE_KEY_MAX_BIT_LENGTH) {
-            int paddingBits = PRIVATE_KEY_MAX_BIT_LENGTH - privateKey.bitLength();
-            BigInteger padding = BigInteger.ZERO.setBit(paddingBits);
-            return padding.or(privateKey);
-        } else {
-            return privateKey;
-        }
-    }
-
     public static BigInteger[] generateChunkOutOfSinglePrivateKey(BigInteger singlePrivateKey, int arraySize) {
         BigInteger[] chunk = new BigInteger[arraySize];
         chunk[0] = singlePrivateKey;
@@ -90,7 +81,7 @@ public class TestHelper {
     /**
      * Simulates the or operation in OpenCL when using the chunk mode
      * <p>
-     * This method will perform a bitwise OR-operation with the last 32 bits of a given BigInteger with a given value
+     * This method will perform a bitwise OR-operation with the last 32 bits of a given BigInteger with the given value
      * <p>
      * <strong>The content of this method was generated with OpenAI/ChatGPT</strong>
      *
@@ -98,7 +89,6 @@ public class TestHelper {
      * @param value  The value which in OpenCL would be the global_id
      * @return The updated number
      */
-    @SuppressWarnings("UnnecessaryLocalVariable")
     public static BigInteger bitwiseOrWithLast32Bits(BigInteger number, int value) {
         // Mask for the last 32 bits
         BigInteger mask = BigInteger.valueOf(0xFFFFFFFFL);

--- a/src/test/java/net/ladenthin/bitcoinaddressfinder/TestHelper.java
+++ b/src/test/java/net/ladenthin/bitcoinaddressfinder/TestHelper.java
@@ -1,0 +1,242 @@
+package net.ladenthin.bitcoinaddressfinder;
+
+import net.ladenthin.bitcoinaddressfinder.configuration.CProducerOpenCL;
+import org.apache.commons.codec.binary.Hex;
+import org.bitcoinj.core.ECKey;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.security.SecureRandom;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class TestHelper {
+
+    private static final int GRID_NUM_BITS = 8;
+    private static final int PRIVATE_KEY_MAX_BIT_LENGTH = 256;
+    private static final int HEX_RADIX = 16;
+
+    public static OpenCLContext createOpenCLContext(boolean chunkMode) {
+        new OpenCLPlatformAssume().assumeOpenCLLibraryLoadableAndOneOpenCL2_0OrGreaterDeviceAvailable();
+        CProducerOpenCL producerOpenCL = new CProducerOpenCL();
+        producerOpenCL.gridNumBits = GRID_NUM_BITS;
+        producerOpenCL.chunkMode = chunkMode;
+        OpenCLContext openCLContext = new OpenCLContext(producerOpenCL);
+
+        try {
+            openCLContext.init();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        return openCLContext;
+    }
+
+    public static String uncompressedPublicKeyHexStringFromPrivateKey(BigInteger privateKey) {
+        return Hex.encodeHexString(ECKey.publicKeyFromPrivate(privateKey, false));
+    }
+
+    public static String uncompressedPublicKeyHexStringFromPrivateKey(String hexString) {
+        return uncompressedPublicKeyHexStringFromPrivateKey(new BigInteger(hexString, 16));
+    }
+
+    public static BigInteger[] generateRandomUncompressedPrivateKeys(int arraySize) {
+        BigInteger[] privateKeys = new BigInteger[arraySize];
+        for (int i = 0; i < arraySize; i++) {
+            privateKeys[i] = KeyUtility.createSecret(PRIVATE_KEY_MAX_BIT_LENGTH, new SecureRandom());
+            ensureMinBitLength(privateKeys[i]);
+            if (!validateBitcoinPrivateKey(privateKeys[i].toString(HEX_RADIX))) {
+                System.out.println(i + ": NOT VALID: " + privateKeys[i].toString(HEX_RADIX));
+            }
+        }
+        return privateKeys;
+    }
+
+    public static boolean validateBitcoinPrivateKey(String privateKeyHex) {
+        BigInteger privateKey;
+        try {
+            privateKey = new BigInteger(privateKeyHex, 16);
+        } catch (NumberFormatException e) {
+            // Invalid hexadecimal string format
+            return false;
+        }
+
+        // Check if the private key is within the valid range
+        BigInteger minPrivateKey = BigInteger.ONE;
+        BigInteger maxPrivateKey = new BigInteger("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364140", 16);
+        if (privateKey.compareTo(minPrivateKey) >= 0 && privateKey.compareTo(maxPrivateKey) <= 0) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    private static void ensureMinBitLength(BigInteger privateKey) {
+        if (privateKey.bitLength() < PRIVATE_KEY_MAX_BIT_LENGTH) {
+            int paddingBits = PRIVATE_KEY_MAX_BIT_LENGTH - privateKey.bitLength();
+            BigInteger padding = BigInteger.ZERO.setBit(paddingBits);
+            privateKey = padding.or(privateKey);
+        }
+    }
+
+    public static BigInteger[] generateChunkOutOfSinglePrivateKey(BigInteger singlePrivateKey, int arraySize) {
+        BigInteger[] chunk = new BigInteger[arraySize];
+        chunk[0] = singlePrivateKey;
+        for (int i = 1; i < chunk.length; i++) {
+            chunk[i] = bitwiseOrWithLast32Bits(singlePrivateKey, i);
+        }
+        return chunk;
+    }
+
+    /**
+     * Simulates the or operation in OpenCL when using the chunk mode
+     * <p>
+     * This method will perform a bitwise OR-operation with the last 32 bits of a given BigInteger with the a given value
+     * <p>
+     * <strong>The content of this method was generated with OpenAI/ChatGPT</strong>
+     *
+     * @param number The secret key as a BigInteger
+     * @param value  The value which in OpenCL would be the global_id
+     * @return The updated number
+     * @noinspection UnnecessaryLocalVariable
+     */
+    public static BigInteger bitwiseOrWithLast32Bits(BigInteger number, int value) {
+        // Mask for the last 32 bits
+        BigInteger mask = BigInteger.valueOf(0xFFFFFFFFL);
+
+        // Extract the last 32 bits as a BigInteger
+        BigInteger last32Bits = number.and(mask);
+
+        // Perform bitwise OR operation with the given value
+        BigInteger result = last32Bits.or(BigInteger.valueOf(value));
+
+        // Update the last 32 bits in the number with the modified value
+        BigInteger updatedNumber = number.and(mask.not()).or(result);
+
+        return updatedNumber;
+    }
+
+    public static BigInteger[] createBigIntegerArrayFromHexStringArray(String[] hexStringArray) {
+        BigInteger[] bigIntegerArray = new BigInteger[hexStringArray.length];
+        for (int i = 0; i < hexStringArray.length; i++) {
+            bigIntegerArray[i] = new BigInteger(hexStringArray[i], HEX_RADIX);
+        }
+        return bigIntegerArray;
+    }
+
+    public static BigInteger[] createBigIntegerArrayFromSingleHexString(String hexString) {
+        return createBigIntegerArrayFromHexStringArray(new String[]{hexString});
+    }
+
+    public static String[] uncompressedPublicKeysHexStringArrayFromPrivateKeysArray(BigInteger[] privateKeysArray) {
+        String[] uncompressedPublicKeysStringArray = new String[privateKeysArray.length];
+        for (int i = 0; i < privateKeysArray.length; i++) {
+            uncompressedPublicKeysStringArray[i] = uncompressedPublicKeyHexStringFromPrivateKey(privateKeysArray[i]);
+        }
+        return uncompressedPublicKeysStringArray;
+    }
+
+    public static String hexStringFromBigInteger(BigInteger bigInteger) {
+        return bigInteger.toString(HEX_RADIX);
+    }
+
+    public static String hexStringFromPublicKeyBytes(PublicKeyBytes publicKeyBytes) {
+        return Hex.encodeHexString(publicKeyBytes.getUncompressed());
+    }
+
+    public static String[] hexStringArrayFromPublicKeyBytesArray(PublicKeyBytes[] publicKeysResult) {
+        String[] hexStringArray = new String[publicKeysResult.length];
+        for (int i = 0; i < publicKeysResult.length; i++) {
+            hexStringArray[i] = hexStringFromPublicKeyBytes(publicKeysResult[i]);
+        }
+        return hexStringArray;
+    }
+
+    public static Map<String, String> createMapFromBigIntegerArrayAndPublicKeyBytesArray(BigInteger[] keyArray, PublicKeyBytes[] valueArray) {
+        Map<String, String> map = new HashMap<>();
+        if (keyArray.length != valueArray.length) {
+            return null;
+        }
+        for (int i = 0; i < keyArray.length; i++) {
+            String keyString = hexStringFromBigInteger(keyArray[i]);
+            String valueString = hexStringFromPublicKeyBytes(valueArray[i]);
+            map.put(keyString, valueString);
+        }
+        return map;
+    }
+
+    public static Map<String, String> createMapFromSecretAndPublicKeys(BigInteger[] keyArray, String[] valueArray) {
+        Map<String, String> map = new HashMap<>();
+        if (keyArray.length != valueArray.length) {
+            return null;
+        }
+        for (int i = 0; i < keyArray.length; i++) {
+            String keyString = hexStringFromBigInteger(keyArray[i]);
+            String valueString = valueArray[i];
+            map.put(keyString, valueString);
+        }
+        return map;
+    }
+
+    public static <T> ActualArray<T> assertThatArray(T[] actualArray) {
+        return new ActualArray<>(actualArray);
+    }
+
+    public static <K, V> ActualMap<K, V> assertThatKeyMap(Map<K, V> actualMap) {
+        return new ActualMap<K, V>(actualMap);
+    }
+
+    public static class ActualArray<T> {
+
+        private final T[] actualArray;
+
+        private ActualArray(T[] actualArray) {
+            this.actualArray = actualArray;
+        }
+
+        public void isEqualTo(T[] expectedArray) {
+            assertThat("None identical length of both arrays!", actualArray.length, is(equalTo(expectedArray.length)));
+            for (int i = 0; i < actualArray.length; i++) {
+                String reason = "Current Element: " + i + "/" + (actualArray.length - 1);
+                assertThat(reason, actualArray[i], is(equalTo(expectedArray[i])));
+            }
+        }
+    }
+
+    public static class ActualMap<K, V> {
+
+        private final Map<K, V> actualMap;
+
+        private ActualMap(Map<K, V> actualMap) {
+            assertThat(actualMap, Matchers.notNullValue());
+            this.actualMap = actualMap;
+        }
+
+        public void isEqualTo(Map<K, V> expectedMap) {
+            assertThat(expectedMap, Matchers.notNullValue());
+            assertThat("None identical length of both maps!", actualMap.size(), is(equalTo(expectedMap.size())));
+            Set<K> expectedKeys = expectedMap.keySet();
+            for (K expectedKey : expectedKeys) {
+                assertThat("Contains key", true, is(actualMap.containsKey(expectedKey)));
+            }
+            int i = 0;
+            for (K expectedKey : expectedKeys) {
+                String reason = "Current Element: " + i + "/" + (actualMap.size() - 1);
+                final V actualValue = actualMap.get(expectedKey);
+                final V expectedValue = expectedMap.get(expectedKey);
+                reason += "\nprivateKey = " + expectedKey.toString();
+                reason += "\nexpectedPublicKey = " + expectedValue.toString();
+                reason += "\nactualValue = " + actualValue.toString();
+                assertThat(reason, actualValue, is(equalTo(expectedValue)));
+                System.out.println(reason);
+                i++;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Introduced the "nonChunkMode", the possibility to feed the OpenCL kernel with 256 different secretKeys/privateKeys instead of only one (in the so called "chunkMode").